### PR TITLE
Fixed a Hat in Time 60 FPS patch for 1.0.3

### DIFF
--- a/A Hat in Time/titles/010056E00853A000/romfs/HatinTimeGame/Config/Switch/SwitchEngine.ini
+++ b/A Hat in Time/titles/010056E00853A000/romfs/HatinTimeGame/Config/Switch/SwitchEngine.ini
@@ -6,3 +6,11 @@ MaxSmoothedFrameRate=60
 bSmoothFrameRate=TRUE
 AllowScreenDoorFade=TRUE
 bKeepAllMaterialQualityLevelsLoaded=FALSE
+TimeBetweenPurgingPendingKillObjects=240
+
+[Core.System]
+MaxObjectsNotConsideredByGC=120000
+SizeOfPermanentObjectPool=20000000
+
+[IniVersion]
+manual=1


### PR DESCRIPTION
I updated the SwitchEngine.ini of a Hat in Time so it would work with the 1.0.3 version of the game.

I tested it and it works.